### PR TITLE
fix: export should be scheduled, not scheduler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const app = new Hono<{ Bindings: CloudflareBindings }>();
 
 export default {
   fetch: app.fetch,
-  scheduler: async (
+  scheduled: async (
     ctrl: ScheduledController,
     env: Env,
     ctx: ExecutionContext,


### PR DESCRIPTION
## Overview

This pull request renames the event handler from `scheduler` to `scheduled`, as expected by Cloudflare Workers.