### PR TITLE
fix: remove emoji tag if users are unknown

### DIFF
--- a/src/scheduler/bugs.ts
+++ b/src/scheduler/bugs.ts
@@ -307,7 +307,6 @@ export async function sendActiveBugReminder(env: Env) {
                             {
                               type: 'text',
                               text: '⚠️',
-                              emoji: true,
                             },
                           ]
                         : issue.assignees.map((assignee) => ({


### PR DESCRIPTION
## Overview

This pull request removes `emoji` property key in blocks section since rich elements don't need them