### PR TITLE
fix: remove emoji key if user doesn't exist

### DIFF
--- a/src/scheduler/bugs.ts
+++ b/src/scheduler/bugs.ts
@@ -307,7 +307,6 @@ export async function sendActiveBugReminder(env: Env) {
                             {
                               type: 'text',
                               text: '⚠️',
-                              emoji: true,
                             },
                           ]
                         : issue.assignees.map((assignee) => ({


### PR DESCRIPTION
## Overview

This pull request removes `emoji` key from rich text block since they don't need the key.