### PR TITLE
fix: check the 10th column instead of the first

### DIFF
--- a/scripts/read.gs
+++ b/scripts/read.gs
@@ -93,11 +93,11 @@ function isExcluded(date) {
 
   const targetRow = getRowByDate(sheet, date);
 
-  const sampleCell = sheet.getRange(targetRow, 1);
+  const sampleCell = sheet.getRange(targetRow, 10);
   const hex = sampleCell.getBackground();
 
   // TODO: add more values?
-  return ['#f4cccc', '#ea9999'].includes(hex);
+  return ['#f4cccc', '#ea9999', '#ff0000'].includes(hex);
 }
 
 function doGet(e) {


### PR DESCRIPTION
## Overview

This pull request fixes how holiday detection works by checking the 10th column instead of the 1st, since the current day first column will always be highlighted in yellow instead of shades of red, making the check non-functional.